### PR TITLE
Fixed typo on multiconn host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Srat's commands
 ## multiconn server
 ```
 usage: ./multiconn-server.py <host> <port>
-./multiconn-server.py 127 .0.0.1 65432 
+./multiconn-server.py 127.0.0.1 65432 
 ```
 ## multiconn client
 ```
 usage: ./multiconn-client.py <host> <port> <num_connections>
-./multiconn-client.py 127 .0.0.1 65432  2
+./multiconn-client.py 127.0.0.1 65432  2
 ```# socket-server-python


### PR DESCRIPTION
There was space between 127 and 0